### PR TITLE
Fix typo in info page

### DIFF
--- a/info/cedille-info-main.info
+++ b/info/cedille-info-main.info
@@ -222,7 +222,7 @@ with some term t’, the notation in Cedille is t -t’.
 
 Finally, one sometimes wishes to give a binding for a more complex
 specificational term for use within an expression.  To facilitate this
-Cedille has notation for erased let-bindings {x : T = t} - t2, where x
+Cedille has notation for erased let-bindings {x : T = t1} - t2, where x
 is the bound variable, t1 its definition, and t2 and expression where x
 is in scope.  The syntax for ordinary let-bindings is [x : T = t1] - t2
 


### PR DESCRIPTION
It talked about `t1` and `t2` within a term `{x : T = t} - t2`.  I believe that term should read `{x : T = t1} - t2`.