### PR TITLE
Specify ./bin directory when building cedille executable

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -5,7 +5,7 @@
     - On MacOS these may already be available if you have xcode libraries installed
 2. In the Cedille repository directory:
     - Run `stack build Agda alex happy`
-    - Run `stack build --copy-bins --local-bin-path .`
+    - Run `mkdir -p ./bin; stack build --copy-bins --local-bin-path ./bin`
 3. Add the following to your `~/.emacs` file, changing the path to match your system
 ```
 (setq cedille-path "/path/to/cedille-dir/")


### PR DESCRIPTION
## Motivation
I am getting Cedille installed today and ran into an issue I had run into in the past before.

The build steps found in this repo (and [here](https://cedille.github.io/BUILD.html)) specify that you should run:
```
stack build --copy-bins --local-bin-path .
```

However, i find that by doing that as well as specifying my cedille dir as

```
(setq cedille-path "~/cedille/cedille/")
```

I get the following error when loading `cedille-mode` in emacs:
```
File mode specification error: (file-error Searching for program No such file or directory ~/cedille/cedille/bin/cedille)
```

Which implies to me that emacs is looking for the cedille executable in `cedille-path + "bin/cedille"`.

Simply moving the executable to `./bin` resolves the issue, which is all I've change in BUILD.md.

I'm not sure if this is a user error on my end or just a lapse in documentation; hopefully this can be merged if it's the latter.
